### PR TITLE
Fixed 5.1 build error - blueprint enums need to be marked as class

### DIFF
--- a/ConfigCat.uplugin
+++ b/ConfigCat.uplugin
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"VersionName": "2.0.0",
+	"VersionName": "2.0.1",
 	"EngineVersion": "5.3",
 	"FriendlyName": "ConfigCat",
 	"Description": "ConfigCat is a hosted service for feature flag and configuration management. It lets you decouple feature releases from code deployments.",

--- a/Source/ConfigCatWrappers/Public/ConfigCatSettingsWrapper.h
+++ b/Source/ConfigCatWrappers/Public/ConfigCatSettingsWrapper.h
@@ -13,7 +13,7 @@ class UConfigCatTargetingRuleWrapper;
 class UConfigCatValueWrapper;
 
 UENUM(BlueprintType)
-enum EConfigCatSettingTypeWrapper : uint8
+enum class EConfigCatSettingTypeWrapper : uint8
 {
 	Bool = 0,
 	String = 1,


### PR DESCRIPTION
### Describe the purpose of your pull request

- Changed blueprint `enum` to `enum class` to get properly parsed by the Unreal Header Tool in 5.1