### PR TITLE
Removed white spaces from auto generated ConfigCat display names

### DIFF
--- a/ConfigCat.uplugin
+++ b/ConfigCat.uplugin
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"VersionName": "2.1.5",
+	"VersionName": "2.1.6",
 	"EngineVersion": "5.4",
 	"FriendlyName": "ConfigCat",
 	"Description": "ConfigCat is a hosted service for feature flag and configuration management. It lets you decouple feature releases from code deployments.",

--- a/Source/ConfigCat/Private/Wrappers/ConfigCatSettingsWrapper.cpp
+++ b/Source/ConfigCat/Private/Wrappers/ConfigCatSettingsWrapper.cpp
@@ -20,9 +20,9 @@ bool UConfigCatSettingWrapper::HasInvalidType() const
 	return Setting.hasInvalidType();
 }
 
-EConfigCatSettingTypeWrapper UConfigCatSettingWrapper::GetType() const
+EConfigCatSettingType UConfigCatSettingWrapper::GetType() const
 {
-	return static_cast<EConfigCatSettingTypeWrapper>(Setting.type);
+	return static_cast<EConfigCatSettingType>(Setting.type);
 }
 
 FString UConfigCatSettingWrapper::GetPercentageOptionsAttribute() const

--- a/Source/ConfigCat/Public/ConfigCatSettings.h
+++ b/Source/ConfigCat/Public/ConfigCatSettings.h
@@ -53,7 +53,7 @@ enum class EOverrideBehaviour : uint8
 /**
  * Holds configuration for integrating the ConfigCat feature flags SDK
  */
-UCLASS(DefaultConfig, Config = ConfigCat)
+UCLASS(DefaultConfig, Config = ConfigCat, meta = (DisplayName = "ConfigCat Settings"))
 class CONFIGCAT_API UConfigCatSettings : public UDeveloperSettings
 {
 	GENERATED_BODY()

--- a/Source/ConfigCat/Public/ConfigCatSubsystem.h
+++ b/Source/ConfigCat/Public/ConfigCatSubsystem.h
@@ -47,97 +47,97 @@ public:
 	/**
 	 * Gets a feature flag of boolean value for a specific key. Optionally takes in a target user.
 	 */
-	UFUNCTION(BlueprintPure, DisplayName = "Get Value (Boolean)", Category = "ConfigCat", meta = (AdvancedDisplay = "bDefaultValue, User", AutoCreateRefTerm = "User"))
+	UFUNCTION(BlueprintPure, DisplayName = "Get Value (Boolean)", Category = "FeatureFlags", meta = (Keywords = "ConfigCat", AdvancedDisplay = "bDefaultValue, User", AutoCreateRefTerm = "User"))
 	bool GetBoolValue(const FString& Key, bool bDefaultValue, const UConfigCatUserWrapper* User = nullptr) const;
 	/**
 	 * Gets a feature flag of integer value for a specific key. Optionally takes in a target user.
 	 */
-	UFUNCTION(BlueprintPure, DisplayName = "Get Value (Integer)", Category = "ConfigCat", meta = (AdvancedDisplay = "DefaultValue, User", AutoCreateRefTerm = "User"))
+	UFUNCTION(BlueprintPure, DisplayName = "Get Value (Integer)", Category = "FeatureFlags", meta = (Keywords = "ConfigCat", AdvancedDisplay = "DefaultValue, User", AutoCreateRefTerm = "User"))
 	int32 GetIntValue(const FString& Key, int32 DefaultValue, const UConfigCatUserWrapper* User = nullptr) const;
 	/**
 	 * Gets a feature flag of decimal (double) value for a specific key. Optionally takes in a target user.
 	 */
-	UFUNCTION(BlueprintPure, DisplayName = "Get Value (Double)", Category = "ConfigCat", meta = (AdvancedDisplay = "DefaultValue, User", AutoCreateRefTerm = "User"))
+	UFUNCTION(BlueprintPure, DisplayName = "Get Value (Double)", Category = "FeatureFlags", meta = (Keywords = "ConfigCat", AdvancedDisplay = "DefaultValue, User", AutoCreateRefTerm = "User"))
 	double GetDoubleValue(const FString& Key, double DefaultValue, const UConfigCatUserWrapper* User = nullptr) const;
 	/**
 	 * Gets a feature flag of string value for a specific key. Optionally takes in a target user.
 	 */
-	UFUNCTION(BlueprintPure, DisplayName = "Get Value (String)", Category = "ConfigCat", meta = (AdvancedDisplay = "DefaultValue, User", AutoCreateRefTerm = "User"))
+	UFUNCTION(BlueprintPure, DisplayName = "Get Value (String)", Category = "FeatureFlags", meta = (Keywords = "ConfigCat", AdvancedDisplay = "DefaultValue, User", AutoCreateRefTerm = "User"))
 	FString GetStringValue(const FString& Key, const FString& DefaultValue, const UConfigCatUserWrapper* User = nullptr) const;
 	/**
 	 * Gets a feature flag of variant value for a specific key. Optionally takes in a target user.
 	 */
-	UFUNCTION(BlueprintPure, DisplayName = "Get Config Value", Category = "ConfigCat", meta = (AdvancedDisplay = "User", AutoCreateRefTerm = "User"))
+	UFUNCTION(BlueprintPure, DisplayName = "Get Config Value", Category = "FeatureFlags", meta = (Keywords = "ConfigCat", AdvancedDisplay = "User", AutoCreateRefTerm = "User"))
 	UConfigCatValueWrapper* GetConfigValue(const FString& Key, const UConfigCatUserWrapper* User = nullptr) const;
 	/**
 	 * Gets the evaluation details of a feature flag of bool value for a specific key. Optionally takes in a target user.
 	 */
-	UFUNCTION(BlueprintPure, DisplayName = "Get Value Details(Boolean)", Category = "ConfigCat", meta = (AdvancedDisplay = "DefaultValue, User", AutoCreateRefTerm = "User"))
+	UFUNCTION(BlueprintPure, DisplayName = "Get Value Details(Boolean)", Category = "FeatureFlags", meta = (Keywords = "ConfigCat", AdvancedDisplay = "DefaultValue, User", AutoCreateRefTerm = "User"))
 	UConfigCatEvaluationWrapper* GetBoolValueDetails(const FString& Key, bool DefaultValue, const UConfigCatUserWrapper* User = nullptr) const;
 	/**
 	 * Gets the evaluation details of a feature flag of integer value for a specific key. Optionally takes in a target user.
 	 */
-	UFUNCTION(BlueprintPure, DisplayName = "Get Value Details(Integer)", Category = "ConfigCat", meta = (AdvancedDisplay = "DefaultValue, User", AutoCreateRefTerm = "User"))
+	UFUNCTION(BlueprintPure, DisplayName = "Get Value Details(Integer)", Category = "FeatureFlags", meta = (Keywords = "ConfigCat", AdvancedDisplay = "DefaultValue, User", AutoCreateRefTerm = "User"))
 	UConfigCatEvaluationWrapper* GetIntValueDetails(const FString& Key, int DefaultValue, const UConfigCatUserWrapper* User = nullptr) const;
 	/**
 	 * Gets the evaluation details of a feature flag of decimal (double) value for a specific key. Optionally takes in a target user.
 	 */
-	UFUNCTION(BlueprintPure, DisplayName = "Get Value Details(Double)", Category = "ConfigCat", meta = (AdvancedDisplay = "DefaultValue, User", AutoCreateRefTerm = "User"))
+	UFUNCTION(BlueprintPure, DisplayName = "Get Value Details(Double)", Category = "FeatureFlags", meta = (Keywords = "ConfigCat", AdvancedDisplay = "DefaultValue, User", AutoCreateRefTerm = "User"))
 	UConfigCatEvaluationWrapper* GetDoubleValueDetails(const FString& Key, double DefaultValue, const UConfigCatUserWrapper* User = nullptr) const;
 	/**
 	 * Gets the evaluation details of a feature flag of string value for a specific key. Optionally takes in a target user.
 	 */
-	UFUNCTION(BlueprintPure, DisplayName = "Get Value Details(String)", Category = "ConfigCat", meta = (AdvancedDisplay = "DefaultValue, User", AutoCreateRefTerm = "User"))
+	UFUNCTION(BlueprintPure, DisplayName = "Get Value Details(String)", Category = "FeatureFlags", meta = (Keywords = "ConfigCat", AdvancedDisplay = "DefaultValue, User", AutoCreateRefTerm = "User"))
 	UConfigCatEvaluationWrapper* GetStringValueDetails(const FString& Key, const FString& DefaultValue, const UConfigCatUserWrapper* User = nullptr) const;
 	/**
 	 * Gets all the setting keys.
 	 */
-	UFUNCTION(BlueprintPure, Category = "ConfigCat")
+	UFUNCTION(BlueprintPure, Category = "FeatureFlags", meta = (Keywords = "ConfigCat"))
 	TArray<FString> GetAllKeys() const;
 	/**
 	 * Gets the key of a setting and it's value identified by the given Variation ID (analytics)
 	 */
-	UFUNCTION(BlueprintPure, Category = "ConfigCat")
+	UFUNCTION(BlueprintPure, Category = "FeatureFlags", meta = (Keywords = "ConfigCat"))
 	bool GetKeyAndValue(const FString& VariationId, FString& OutKey, UConfigCatValueWrapper*& OutValue) const;
 	/**
 	 * Gets the values of all feature flags or settings.
 	 */
-	UFUNCTION(BlueprintPure, Category = "ConfigCat", meta = (AdvancedDisplay = "User", AutoCreateRefTerm = "User"))
+	UFUNCTION(BlueprintPure, Category = "FeatureFlags", meta = (Keywords = "ConfigCat", AdvancedDisplay = "User", AutoCreateRefTerm = "User"))
 	TMap<FString, UConfigCatValueWrapper*> GetAllValues(const UConfigCatUserWrapper* User = nullptr) const;
 	/**
 	 * Gets the values along with evaluation details of all feature flags and settings.
 	 */
-	UFUNCTION(BlueprintPure, Category = "ConfigCat", meta = (AdvancedDisplay = "User", AutoCreateRefTerm = "User"))
+	UFUNCTION(BlueprintPure, Category = "FeatureFlags", meta = (Keywords = "ConfigCat", AdvancedDisplay = "User", AutoCreateRefTerm = "User"))
 	TArray<UConfigCatEvaluationWrapper*> GetAllValueDetails(const UConfigCatUserWrapper* User = nullptr) const;
 	/**
 	 * Initiates a force refresh synchronously on the cached configuration.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "ConfigCat")
+	UFUNCTION(BlueprintCallable, Category = "FeatureFlags", meta = (Keywords = "ConfigCat"))
 	void ForceRefresh();
 	/**
 	 * Sets the default user.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "ConfigCat")
+	UFUNCTION(BlueprintCallable, Category = "Targeting", meta = (Keywords = "ConfigCat"))
 	void SetDefaultUser(const UConfigCatUserWrapper* User = nullptr);
 	/**
 	 * Sets the default user to nullptr.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "ConfigCat")
+	UFUNCTION(BlueprintCallable, Category = "Targeting", meta = (Keywords = "ConfigCat"))
 	void ClearDefaultUser();
 	/**
 	 * Configures the SDK to allow HTTP requests.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "ConfigCat")
+	UFUNCTION(BlueprintCallable, Category = "Connection", meta = (Keywords = "ConfigCat"))
 	void SetOnline();
 	/**
 	 * Configures the SDK to not initiate HTTP requests and work only from its cache.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "ConfigCat")
+	UFUNCTION(BlueprintCallable, Category = "Connection", meta = (Keywords = "ConfigCat"))
 	void SetOffline();
 	/**
 	 * true when the SDK is configured not to initiate HTTP requests, otherwise false.
 	 */
-	UFUNCTION(BlueprintPure, Category = "ConfigCat")
+	UFUNCTION(BlueprintPure, Category = "Connection", meta = (Keywords = "ConfigCat"))
 	bool IsOffline() const;
 	/**
 	 * Executed when the configcat client is fully initialized.

--- a/Source/ConfigCat/Public/ConfigCatSubsystem.h
+++ b/Source/ConfigCat/Public/ConfigCatSubsystem.h
@@ -33,7 +33,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnErrorBp, const FString&, Error, 
 /**
  * Wrapper for accessing the configcat client. This subsystem is responsible for initializing and managing the client's lifecycle.
  */
-UCLASS()
+UCLASS(meta = (DisplayName = "ConfigCat Subsystem"))
 class CONFIGCAT_API UConfigCatSubsystem : public UGameInstanceSubsystem
 {
 	GENERATED_BODY()

--- a/Source/ConfigCat/Public/Wrappers/ConfigCatEvaluationWrapper.h
+++ b/Source/ConfigCat/Public/Wrappers/ConfigCatEvaluationWrapper.h
@@ -22,25 +22,25 @@ class CONFIGCAT_API UConfigCatEvaluationWrapper : public UObject
 public:
 	static UConfigCatEvaluationWrapper* CreateEvaluation(const configcat::EvaluationDetailsBase& InEvaluationDetails);
 
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|EvaluationDetails")
+	UFUNCTION(BlueprintPure, Category = "EvaluationDetails", meta = (Keywords = "ConfigCat"))
 	FString GetKey() const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|EvaluationDetails")
+	UFUNCTION(BlueprintPure, Category = "EvaluationDetails", meta = (Keywords = "ConfigCat"))
 	FString GetVariationId() const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|EvaluationDetails")
+	UFUNCTION(BlueprintPure, Category = "EvaluationDetails", meta = (Keywords = "ConfigCat"))
 	FDateTime GetFetchTime() const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|EvaluationDetails")
+	UFUNCTION(BlueprintPure, Category = "EvaluationDetails", meta = (Keywords = "ConfigCat"))
 	UConfigCatUserWrapper* GetUser() const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|EvaluationDetails")
+	UFUNCTION(BlueprintPure, Category = "EvaluationDetails", meta = (Keywords = "ConfigCat"))
 	bool IsDefaultValue() const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|EvaluationDetails")
+	UFUNCTION(BlueprintPure, Category = "EvaluationDetails", meta = (Keywords = "ConfigCat"))
 	FString GetError() const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|EvaluationDetails")
+	UFUNCTION(BlueprintPure, Category = "EvaluationDetails", meta = (Keywords = "ConfigCat"))
 	FString GetException() const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|EvaluationDetails")
+	UFUNCTION(BlueprintPure, Category = "EvaluationDetails", meta = (Keywords = "ConfigCat"))
 	UConfigCatTargetingRuleWrapper* GetMatchedTargetingRule() const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|EvaluationDetails")
+	UFUNCTION(BlueprintPure, Category = "EvaluationDetails", meta = (Keywords = "ConfigCat"))
 	UConfigCatPercentageOptionWrapper* GetMatchedPercentageOption() const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|EvaluationDetails")
+	UFUNCTION(BlueprintPure, Category = "EvaluationDetails", meta = (Keywords = "ConfigCat"))
 	UConfigCatValueWrapper* GetValue() const;
 
 	std::shared_ptr<configcat::EvaluationDetails<>> EvaluationDetails;

--- a/Source/ConfigCat/Public/Wrappers/ConfigCatEvaluationWrapper.h
+++ b/Source/ConfigCat/Public/Wrappers/ConfigCatEvaluationWrapper.h
@@ -14,7 +14,7 @@ class UConfigCatTargetingRuleWrapper;
 class UConfigCatUserWrapper;
 class UConfigCatValueWrapper;
 
-UCLASS(DisplayName="Config Cat Evaluation")
+UCLASS(meta = (DisplayName = "ConfigCat Evaluation"))
 class CONFIGCAT_API UConfigCatEvaluationWrapper : public UObject
 {
 	GENERATED_BODY()

--- a/Source/ConfigCat/Public/Wrappers/ConfigCatPercentageOptionWrapper.h
+++ b/Source/ConfigCat/Public/Wrappers/ConfigCatPercentageOptionWrapper.h
@@ -16,13 +16,13 @@ class CONFIGCAT_API UConfigCatPercentageOptionWrapper : public UObject
 public:
 	static UConfigCatPercentageOptionWrapper* CreatePercentageOption(const configcat::PercentageOption& InPercentageOption);
 
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|PercentageOption")
+	UFUNCTION(BlueprintPure, Category = "PercentageOption", meta = (Keywords = "ConfigCat"))
 	uint8 GetPercentage() const;
 
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|PercentageOption")
+	UFUNCTION(BlueprintPure, Category = "PercentageOption", meta = (Keywords = "ConfigCat"))
 	FString GetVariationId() const;
 	
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|PercentageOption")
+	UFUNCTION(BlueprintPure, Category = "PercentageOption", meta = (Keywords = "ConfigCat"))
 	UConfigCatValueWrapper* GetValue() const;
 	
 	configcat::PercentageOption PercentageOption;

--- a/Source/ConfigCat/Public/Wrappers/ConfigCatPercentageOptionWrapper.h
+++ b/Source/ConfigCat/Public/Wrappers/ConfigCatPercentageOptionWrapper.h
@@ -8,7 +8,7 @@
 
 class UConfigCatValueWrapper;
 
-UCLASS(DisplayName="Config Cat Percentage Option")
+UCLASS(meta = (DisplayName = "ConfigCat Percentage Option"))
 class CONFIGCAT_API UConfigCatPercentageOptionWrapper : public UObject
 {
 	GENERATED_BODY()

--- a/Source/ConfigCat/Public/Wrappers/ConfigCatSettingValueContainerWrapper.h
+++ b/Source/ConfigCat/Public/Wrappers/ConfigCatSettingValueContainerWrapper.h
@@ -9,7 +9,7 @@
 #include "ConfigCatSettingValueContainerWrapper.generated.h"
 
 class UConfigCatValueWrapper;
-UCLASS(DisplayName="Config Cat Setting Value Container")
+UCLASS(meta = (DisplayName = "ConfigCat Setting Value Container"))
 class CONFIGCAT_API UConfigCatSettingValueContainerWrapper : public UObject
 {
 	GENERATED_BODY()

--- a/Source/ConfigCat/Public/Wrappers/ConfigCatSettingValueContainerWrapper.h
+++ b/Source/ConfigCat/Public/Wrappers/ConfigCatSettingValueContainerWrapper.h
@@ -17,9 +17,9 @@ class CONFIGCAT_API UConfigCatSettingValueContainerWrapper : public UObject
 public:
 	static UConfigCatSettingValueContainerWrapper* CreateSettingValue(const configcat::SettingValueContainer& SettingValueContainer);
 
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|SettingValueContainer")
+	UFUNCTION(BlueprintPure, Category = "SettingValueContainer", meta = (Keywords = "ConfigCat"))
 	FString GetVariationId() const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|SettingValueContainer")
+	UFUNCTION(BlueprintPure, Category = "SettingValueContainer", meta = (Keywords = "ConfigCat"))
 	UConfigCatValueWrapper* GetValue() const;
 
 	configcat::SettingValueContainer SettingValueContainer;

--- a/Source/ConfigCat/Public/Wrappers/ConfigCatSettingsWrapper.h
+++ b/Source/ConfigCat/Public/Wrappers/ConfigCatSettingsWrapper.h
@@ -29,25 +29,25 @@ class CONFIGCAT_API UConfigCatSettingWrapper : public UObject
 public:
 	static UConfigCatSettingWrapper* CreateSetting(const configcat::Setting& InSetting);
 
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|Setting")
+	UFUNCTION(BlueprintPure, Category = "Setting", meta = (Keywords = "ConfigCat"))
 	FString GetVariationId() const;
 
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|Setting")
+	UFUNCTION(BlueprintPure, Category = "Setting", meta = (Keywords = "ConfigCat"))
 	FString GetPercentageOptionsAttribute() const;
 	
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|Setting")
+	UFUNCTION(BlueprintPure, Category = "Setting", meta = (Keywords = "ConfigCat"))
 	bool HasInvalidType() const;
 	
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|Setting")
+	UFUNCTION(BlueprintPure, Category = "Setting", meta = (Keywords = "ConfigCat"))
 	EConfigCatSettingType GetType() const;
 	
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|Setting")
+	UFUNCTION(BlueprintPure, Category = "Setting", meta = (Keywords = "ConfigCat"))
 	UConfigCatValueWrapper* GetValue() const;
 	
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|Setting")
+	UFUNCTION(BlueprintPure, Category = "Setting", meta = (Keywords = "ConfigCat"))
 	TArray<UConfigCatTargetingRuleWrapper*> GetTargetingRules() const;
 
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|Setting")
+	UFUNCTION(BlueprintPure, Category = "Setting", meta = (Keywords = "ConfigCat"))
 	TArray<UConfigCatPercentageOptionWrapper*> GetPercentageOptions() const;
 
 	configcat::Setting Setting;
@@ -61,7 +61,7 @@ class CONFIGCAT_API UConfigCatSettingsWrapper : public UObject
 public:
 	static UConfigCatSettingsWrapper* CreateSettings(const std::shared_ptr<const configcat::Settings>& InSettings);
 
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|Settings")
+	UFUNCTION(BlueprintPure, Category = "Settings", meta = (Keywords = "ConfigCat"))
 	TMap<FString, UConfigCatSettingWrapper*> GetSettings() const;
 
 	std::shared_ptr<const configcat::Settings> Settings;

--- a/Source/ConfigCat/Public/Wrappers/ConfigCatSettingsWrapper.h
+++ b/Source/ConfigCat/Public/Wrappers/ConfigCatSettingsWrapper.h
@@ -12,8 +12,8 @@ class UConfigCatPercentageOptionWrapper;
 class UConfigCatTargetingRuleWrapper;
 class UConfigCatValueWrapper;
 
-UENUM(BlueprintType)
-enum class EConfigCatSettingTypeWrapper : uint8
+UENUM(BlueprintType, meta = (DisplayName = "ConfigCat Setting Type"))
+enum class EConfigCatSettingType : uint8
 {
 	Bool = 0,
 	String = 1,
@@ -21,7 +21,7 @@ enum class EConfigCatSettingTypeWrapper : uint8
 	Double = 3,
 };
 
-UCLASS(DisplayName="Config Cat Setting")
+UCLASS(meta = (DisplayName = "ConfigCat Setting"))
 class CONFIGCAT_API UConfigCatSettingWrapper : public UObject 
 {
 	GENERATED_BODY()
@@ -39,7 +39,7 @@ public:
 	bool HasInvalidType() const;
 	
 	UFUNCTION(BlueprintPure, Category = "ConfigCat|Setting")
-	EConfigCatSettingTypeWrapper GetType() const;
+	EConfigCatSettingType GetType() const;
 	
 	UFUNCTION(BlueprintPure, Category = "ConfigCat|Setting")
 	UConfigCatValueWrapper* GetValue() const;
@@ -53,7 +53,7 @@ public:
 	configcat::Setting Setting;
 };
 
-UCLASS(DisplayName="Config Cat Settings")
+UCLASS(meta = (DisplayName = "ConfigCat Settings"))
 class CONFIGCAT_API UConfigCatSettingsWrapper : public UObject
 {
 	GENERATED_BODY()

--- a/Source/ConfigCat/Public/Wrappers/ConfigCatTargetingRuleWrapper.h
+++ b/Source/ConfigCat/Public/Wrappers/ConfigCatTargetingRuleWrapper.h
@@ -61,25 +61,25 @@ class CONFIGCAT_API UConfigCatUserConditionWrapper : public UObject
 public:
 	static UConfigCatUserConditionWrapper* CreateUserCondition(const configcat::UserCondition& InUserCondition);
 	
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|UserCondition")
+	UFUNCTION(BlueprintPure, Category = "UserCondition", meta = (Keywords = "ConfigCat"))
 	FString GetComparisonAttribute() const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|UserCondition")
+	UFUNCTION(BlueprintPure, Category = "UserCondition", meta = (Keywords = "ConfigCat"))
 	EConfigCatUserComparator GetComparator() const;
 
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|UserCondition")
+	UFUNCTION(BlueprintPure, Category = "UserCondition", meta = (Keywords = "ConfigCat"))
 	bool HasAnyComparisonValue();
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|UserCondition")
+	UFUNCTION(BlueprintPure, Category = "UserCondition", meta = (Keywords = "ConfigCat"))
    	bool HasStringComparisonValue() const;
-   	UFUNCTION(BlueprintPure, Category = "ConfigCat|UserCondition")
+   	UFUNCTION(BlueprintPure, Category = "UserCondition", meta = (Keywords = "ConfigCat"))
    	bool HasNumberComparisonValue() const;
-   	UFUNCTION(BlueprintPure, Category = "ConfigCat|UserCondition")
+   	UFUNCTION(BlueprintPure, Category = "UserCondition", meta = (Keywords = "ConfigCat"))
    	bool HasStringArrayComparisonValue() const;
 
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|UserCondition")
+	UFUNCTION(BlueprintPure, Category = "UserCondition", meta = (Keywords = "ConfigCat"))
 	FString GetStringComparisonValue() const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|UserCondition")
+	UFUNCTION(BlueprintPure, Category = "UserCondition", meta = (Keywords = "ConfigCat"))
 	double GetNumberComparisonValue() const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|UserCondition")
+	UFUNCTION(BlueprintPure, Category = "UserCondition", meta = (Keywords = "ConfigCat"))
 	TArray<FString> GetStringArrayComparisonValue() const;
 
 	configcat::UserCondition UserCondition;
@@ -101,11 +101,11 @@ class CONFIGCAT_API UConfigCatPrerequisiteFlagConditionWrapper : public UObject
 public:
 	static UConfigCatPrerequisiteFlagConditionWrapper* CreatePrerequisiteFlagCondition(const configcat::PrerequisiteFlagCondition& InPrerequisiteFlagCondition);
 	
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|PrerequisiteFlagCondition")
+	UFUNCTION(BlueprintPure, Category = "PrerequisiteFlagCondition", meta = (Keywords = "ConfigCat"))
 	FString GetPrerequisiteFlagKey() const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|PrerequisiteFlagCondition")
+	UFUNCTION(BlueprintPure, Category = "PrerequisiteFlagCondition", meta = (Keywords = "ConfigCat"))
 	EConfigCatPrerequisiteFlagComparator GetComparator() const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|PrerequisiteFlagCondition")
+	UFUNCTION(BlueprintPure, Category = "PrerequisiteFlagCondition", meta = (Keywords = "ConfigCat"))
 	UConfigCatValueWrapper* GetComparisonValue() const;
 
 	configcat::PrerequisiteFlagCondition PrerequisiteFlagCondition;
@@ -127,9 +127,9 @@ class CONFIGCAT_API UConfigCatSegmentConditionWrapper : public UObject
 public:
 	static UConfigCatSegmentConditionWrapper* CreateSegmentCondition(const configcat::SegmentCondition& InSegmentCondition);
 	
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|SegmentCondition")
+	UFUNCTION(BlueprintPure, Category = "SegmentCondition", meta = (Keywords = "ConfigCat"))
 	int32 GetSegmentIndex() const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|SegmentCondition")
+	UFUNCTION(BlueprintPure, Category = "SegmentCondition", meta = (Keywords = "ConfigCat"))
 	EConfigCatSegmentComparator GetComparator() const;
 
 	configcat::SegmentCondition SegmentCondition;
@@ -140,11 +140,11 @@ struct CONFIGCAT_API FConfigCatConditionContainer
 {
 	GENERATED_BODY()
 	
-	UPROPERTY(BlueprintReadOnly, Category = "ConfigCat|ConditionContainer")
+	UPROPERTY(BlueprintReadOnly, Category = "ConditionContainer", meta = (Keywords = "ConfigCat"))
 	UConfigCatUserConditionWrapper* UserCondition;
-	UPROPERTY(BlueprintReadOnly, Category = "ConfigCat|ConditionContainer")
+	UPROPERTY(BlueprintReadOnly, Category = "ConditionContainer", meta = (Keywords = "ConfigCat"))
 	UConfigCatPrerequisiteFlagConditionWrapper* PrerequisiteFlagCondition;
-	UPROPERTY(BlueprintReadOnly, Category = "ConfigCat|ConditionContainer")
+	UPROPERTY(BlueprintReadOnly, Category = "ConditionContainer", meta = (Keywords = "ConfigCat"))
 	UConfigCatSegmentConditionWrapper* SegmentCondition;
 };
 
@@ -153,10 +153,10 @@ struct FConfigCatThenContainer
 {
 	GENERATED_BODY()
 
-	UPROPERTY(BlueprintReadOnly, Category = "ConfigCat|ThenContainer")
+	UPROPERTY(BlueprintReadOnly, Category = "ThenContainer", meta = (Keywords = "ConfigCat"))
 	UConfigCatSettingValueContainerWrapper* SettingValueContainer = nullptr;
 	
-	UPROPERTY(BlueprintReadOnly, Category = "ConfigCat|ThenContainer")
+	UPROPERTY(BlueprintReadOnly, Category = "ThenContainer", meta = (Keywords = "ConfigCat"))
 	TArray<UConfigCatPercentageOptionWrapper*> PercentageOptions;
 };
 
@@ -168,9 +168,9 @@ class CONFIGCAT_API UConfigCatTargetingRuleWrapper : public UObject
 public:
 	static UConfigCatTargetingRuleWrapper* CreateTargetingRule(const configcat::TargetingRule& InTargetingRule);
 
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|TargetingRule")
+	UFUNCTION(BlueprintPure, Category = "TargetingRule", meta = (Keywords = "ConfigCat"))
 	TArray<FConfigCatConditionContainer> GetConditions() const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|TargetingRule")
+	UFUNCTION(BlueprintPure, Category = "TargetingRule", meta = (Keywords = "ConfigCat"))
 	FConfigCatThenContainer GetThen() const;
 
 	configcat::TargetingRule TargetingRule;

--- a/Source/ConfigCat/Public/Wrappers/ConfigCatTargetingRuleWrapper.h
+++ b/Source/ConfigCat/Public/Wrappers/ConfigCatTargetingRuleWrapper.h
@@ -10,7 +10,7 @@ class UConfigCatSettingValueContainerWrapper;
 class UConfigCatPercentageOptionWrapper;
 class UConfigCatValueWrapper;
 
-UENUM(BlueprintType)
+UENUM(BlueprintType, meta = (DisplayName = "ConfigCat User Comparator"))
 enum class EConfigCatUserComparator : uint8
 {
 	TextIsOneOf = 0,
@@ -53,7 +53,7 @@ enum class EConfigCatUserComparator : uint8
 	Invalid
 };
 
-UCLASS(DisplayName="Config Cat User Condition")
+UCLASS(meta = (DisplayName = "ConfigCat User Condition"))
 class CONFIGCAT_API UConfigCatUserConditionWrapper : public UObject
 {
 	GENERATED_BODY()
@@ -85,7 +85,7 @@ public:
 	configcat::UserCondition UserCondition;
 };
 
-UENUM(BlueprintType)
+UENUM(BlueprintType, meta = (DisplayName = "ConfigCat Prerequisite Flag Comparator"))
 enum class EConfigCatPrerequisiteFlagComparator : uint8
 {
 	Equals = 0,
@@ -93,7 +93,7 @@ enum class EConfigCatPrerequisiteFlagComparator : uint8
 	Invalid
 };
 
-UCLASS(DisplayName="Config Cat Prerequisite Flag Condition")
+UCLASS(meta = (DisplayName = "ConfigCat Prerequisite Flag Condition"))
 class CONFIGCAT_API UConfigCatPrerequisiteFlagConditionWrapper : public UObject
 {
 	GENERATED_BODY()
@@ -111,7 +111,7 @@ public:
 	configcat::PrerequisiteFlagCondition PrerequisiteFlagCondition;
 };
 
-UENUM(BlueprintType)
+UENUM(BlueprintType, meta = (DisplayName = "ConfigCat Segment Comparator"))
 enum class EConfigCatSegmentComparator : uint8
 {
 	IsIn = 0,
@@ -119,7 +119,7 @@ enum class EConfigCatSegmentComparator : uint8
 	Invalid
 };
 
-UCLASS(DisplayName="Config Cat Segment Condition")
+UCLASS(meta = (DisplayName = "ConfigCat Segment Condition"))
 class CONFIGCAT_API UConfigCatSegmentConditionWrapper : public UObject
 {
 	GENERATED_BODY()
@@ -135,7 +135,7 @@ public:
 	configcat::SegmentCondition SegmentCondition;
 };
 
-USTRUCT(BlueprintType)
+USTRUCT(BlueprintType, meta = (DisplayName = "ConfigCat Condition Container"))
 struct CONFIGCAT_API FConfigCatConditionContainer
 {
 	GENERATED_BODY()
@@ -148,7 +148,7 @@ struct CONFIGCAT_API FConfigCatConditionContainer
 	UConfigCatSegmentConditionWrapper* SegmentCondition;
 };
 
-USTRUCT(BlueprintType)
+USTRUCT(BlueprintType, meta = (DisplayName = "ConfigCat Then Container"))
 struct FConfigCatThenContainer
 {
 	GENERATED_BODY()
@@ -160,7 +160,7 @@ struct FConfigCatThenContainer
 	TArray<UConfigCatPercentageOptionWrapper*> PercentageOptions;
 };
 
-UCLASS(DisplayName="Config Cat Targeting Rule")
+UCLASS(meta = (DisplayName = "ConfigCat Targeting Rule"))
 class CONFIGCAT_API UConfigCatTargetingRuleWrapper : public UObject
 {
 	GENERATED_BODY()

--- a/Source/ConfigCat/Public/Wrappers/ConfigCatUserWrapper.h
+++ b/Source/ConfigCat/Public/Wrappers/ConfigCatUserWrapper.h
@@ -19,7 +19,7 @@ class CONFIGCAT_API UConfigCatUserWrapper : public UObject
 	GENERATED_BODY()
 
 public:
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|User", meta = (AdvancedDisplay = "Email, Country, Attributes", AutoCreateRefTerm = "Attributes"))
+	UFUNCTION(BlueprintPure, Category = "User", meta = (Keywords = "ConfigCat", AdvancedDisplay = "Email, Country, Attributes", AutoCreateRefTerm = "Attributes"))
 	static UConfigCatUserWrapper* CreateUser(const FString& Id, const FString& Email, const FString& Country, const TMap<FString, FString>& Attributes);
 	static UConfigCatUserWrapper* CreateUser(const FString& Id, const FString& Email = TEXT(""), const FString& Country = TEXT(""));
 	static UConfigCatUserWrapper* CreateUser(const std::shared_ptr<configcat::ConfigCatUser>& InUser);
@@ -27,27 +27,27 @@ public:
 	/**
 	 * Gets the Id of a ConfigCatUser
 	 */
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|User")
+	UFUNCTION(BlueprintPure, Category = "User", meta = (Keywords = "ConfigCat"))
 	FString GetIdentifier() const;
 
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|User")
+	UFUNCTION(BlueprintPure, Category = "User", meta = (Keywords = "ConfigCat"))
 	FString GetStringAttribute(const FString& Key) const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|User")
+	UFUNCTION(BlueprintPure, Category = "User", meta = (Keywords = "ConfigCat"))
 	double GetNumberAttribute(const FString& Key) const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|User")
+	UFUNCTION(BlueprintPure, Category = "User", meta = (Keywords = "ConfigCat"))
 	FDateTime GetTimeAttribute(const FString& Key) const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|User")
+	UFUNCTION(BlueprintPure, Category = "User", meta = (Keywords = "ConfigCat"))
 	TArray<FString> GetStringArrayAttribute(const FString& Key) const;
 
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|User")
+	UFUNCTION(BlueprintPure, Category = "User", meta = (Keywords = "ConfigCat"))
 	bool HasAnyAttribute(const FString& Key) const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|User")
+	UFUNCTION(BlueprintPure, Category = "User", meta = (Keywords = "ConfigCat"))
 	bool HasStringAttribute(const FString& Key) const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|User")
+	UFUNCTION(BlueprintPure, Category = "User", meta = (Keywords = "ConfigCat"))
 	bool HasNumberAttribute(const FString& Key) const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|User")
+	UFUNCTION(BlueprintPure, Category = "User", meta = (Keywords = "ConfigCat"))
 	bool HasTimeAttribute(const FString& Key) const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|User")
+	UFUNCTION(BlueprintPure, Category = "User", meta = (Keywords = "ConfigCat"))
 	bool HasStringArrayAttribute(const FString& Key) const;
 
 	std::shared_ptr<configcat::ConfigCatUser> User;

--- a/Source/ConfigCat/Public/Wrappers/ConfigCatUserWrapper.h
+++ b/Source/ConfigCat/Public/Wrappers/ConfigCatUserWrapper.h
@@ -13,7 +13,7 @@ namespace configcat
 	class ConfigCatUser;
 }
 
-UCLASS(DisplayName="Config Cat User")
+UCLASS(meta = (DisplayName = "ConfigCat User"))
 class CONFIGCAT_API UConfigCatUserWrapper : public UObject
 {
 	GENERATED_BODY()

--- a/Source/ConfigCat/Public/Wrappers/ConfigCatValueWrapper.h
+++ b/Source/ConfigCat/Public/Wrappers/ConfigCatValueWrapper.h
@@ -18,24 +18,24 @@ public:
 	static UConfigCatValueWrapper* CreateValue(const configcat::Value& InValue);
 	static UConfigCatValueWrapper* CreateValue(const std::optional<configcat::Value>& InValue);
 
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|Value")
+	UFUNCTION(BlueprintPure, Category = "Value", meta = (Keywords = "ConfigCat"))
 	bool HasAnyValue() const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|Value")
+	UFUNCTION(BlueprintPure, Category = "Value", meta = (Keywords = "ConfigCat"))
 	bool HasBooleanValue() const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|Value")
+	UFUNCTION(BlueprintPure, Category = "Value", meta = (Keywords = "ConfigCat"))
 	bool HasStringValue() const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|Value")
+	UFUNCTION(BlueprintPure, Category = "Value", meta = (Keywords = "ConfigCat"))
 	bool HasIntegerValue() const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|Value")
+	UFUNCTION(BlueprintPure, Category = "Value", meta = (Keywords = "ConfigCat"))
 	bool HasDecimalValue() const;
 
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|Value")
+	UFUNCTION(BlueprintPure, Category = "Value", meta = (Keywords = "ConfigCat"))
 	bool GetBooleanValue() const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|Value")
+	UFUNCTION(BlueprintPure, Category = "Value", meta = (Keywords = "ConfigCat"))
 	FString GetStringValue() const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|Value")
+	UFUNCTION(BlueprintPure, Category = "Value", meta = (Keywords = "ConfigCat"))
 	int GetIntegerValue() const;
-	UFUNCTION(BlueprintPure, Category = "ConfigCat|Value")
+	UFUNCTION(BlueprintPure, Category = "Value", meta = (Keywords = "ConfigCat"))
 	double GetDecimalValue() const;
 
 	std::optional<configcat::Value> Value;

--- a/Source/ConfigCat/Public/Wrappers/ConfigCatValueWrapper.h
+++ b/Source/ConfigCat/Public/Wrappers/ConfigCatValueWrapper.h
@@ -8,7 +8,7 @@
 
 #include "ConfigCatValueWrapper.generated.h"
 
-UCLASS(DisplayName="Config Cat SettingValue")
+UCLASS(meta = (DisplayName = "ConfigCat Value"))
 class CONFIGCAT_API UConfigCatValueWrapper : public UObject
 {
 	GENERATED_BODY()

--- a/Source/ConfigCatEditor/Private/ConfigCatEditor.cpp
+++ b/Source/ConfigCatEditor/Private/ConfigCatEditor.cpp
@@ -2,4 +2,23 @@
 
 #include "ConfigCatEditor.h"
 
+#include <PropertyEditorModule.h>
+
+#include "ConfigCatSettings.h"
+#include "ConfigCatSettingsDetailCustomization.h"
+
+void FConfigCatEditorModule::StartupModule()
+{
+	FPropertyEditorModule& PropertyModule = FModuleManager::LoadModuleChecked<FPropertyEditorModule>("PropertyEditor");
+	PropertyModule.RegisterCustomClassLayout(UConfigCatSettings::StaticClass()->GetFName(), FOnGetDetailCustomizationInstance::CreateStatic(&FConfigCatSettingsDetailCustomization::MakeInstance));
+}
+
+void FConfigCatEditorModule::ShutdownModule()
+{
+	if (FPropertyEditorModule* PropertyModule = FModuleManager::GetModulePtr<FPropertyEditorModule>("PropertyEditor"))
+	{
+		PropertyModule->UnregisterCustomClassLayout(UConfigCatSettings::StaticClass()->GetFName());
+	}
+}
+
 IMPLEMENT_MODULE(FConfigCatEditorModule, ConfigCatEditor)

--- a/Source/ConfigCatEditor/Private/ConfigCatSettingsDetailCustomization.cpp
+++ b/Source/ConfigCatEditor/Private/ConfigCatSettingsDetailCustomization.cpp
@@ -1,0 +1,17 @@
+﻿// Copyright (c) ConfigCat 2024. All Rights Reserved.
+
+#include "ConfigCatSettingsDetailCustomization.h"
+
+#include <DetailLayoutBuilder.h>
+
+TSharedRef<IDetailCustomization> FConfigCatSettingsDetailCustomization::MakeInstance()
+{
+	return MakeShared<FConfigCatSettingsDetailCustomization>();
+}
+
+void FConfigCatSettingsDetailCustomization::CustomizeDetails(IDetailLayoutBuilder& DetailBuilder)
+{
+	// By default, Unreal splits the category display name based on capitalization (ConfigCat → Config Cat)
+	// To avoid this we are overriding the ConfigCat category and forcing it to show up as ConfigCat (without a space)
+	DetailBuilder.EditCategory("ConfigCat", INVTEXT("ConfigCat"));
+}

--- a/Source/ConfigCatEditor/Public/ConfigCatEditor.h
+++ b/Source/ConfigCatEditor/Public/ConfigCatEditor.h
@@ -9,4 +9,8 @@
  */
 class FConfigCatEditorModule : public IModuleInterface
 {
+	// Begin IModuleInterface interface
+	virtual void StartupModule() override;
+	virtual void ShutdownModule() override;
+	// End IModuleInterface interface
 };

--- a/Source/ConfigCatEditor/Public/ConfigCatSettingsDetailCustomization.h
+++ b/Source/ConfigCatEditor/Public/ConfigCatSettingsDetailCustomization.h
@@ -1,0 +1,17 @@
+﻿// Copyright (c) ConfigCat 2024. All Rights Reserved.
+
+#pragma once
+
+#include <IDetailCustomization.h>
+#include <Templates/SharedPointer.h>
+
+class FConfigCatSettingsDetailCustomization final : public IDetailCustomization
+{
+public:
+	static TSharedRef<IDetailCustomization> MakeInstance();
+
+private:
+	// Begin IDetailCustomization interface
+	virtual void CustomizeDetails(IDetailLayoutBuilder& DetailBuilder) override;
+	// End IDetailCustomization interface
+};


### PR DESCRIPTION
### Describe the purpose of your pull request

- Removed the space from the Project Settings ConfigCat properties
- Removed the parent category `ConfigCat` and replaced it with keywords
- Added display name to all types exposed to blueprints to remove the auto-generated display names.

