### PR TITLE
Fixed pointer initialization warnings

### DIFF
--- a/Source/ConfigCat/Public/Wrappers/ConfigCatTargetingRuleWrapper.h
+++ b/Source/ConfigCat/Public/Wrappers/ConfigCatTargetingRuleWrapper.h
@@ -141,11 +141,11 @@ struct CONFIGCAT_API FConfigCatConditionContainer
 	GENERATED_BODY()
 	
 	UPROPERTY(BlueprintReadOnly, Category = "ConditionContainer", meta = (Keywords = "ConfigCat"))
-	UConfigCatUserConditionWrapper* UserCondition;
+	UConfigCatUserConditionWrapper* UserCondition = nullptr;
 	UPROPERTY(BlueprintReadOnly, Category = "ConditionContainer", meta = (Keywords = "ConfigCat"))
-	UConfigCatPrerequisiteFlagConditionWrapper* PrerequisiteFlagCondition;
+	UConfigCatPrerequisiteFlagConditionWrapper* PrerequisiteFlagCondition = nullptr;
 	UPROPERTY(BlueprintReadOnly, Category = "ConditionContainer", meta = (Keywords = "ConfigCat"))
-	UConfigCatSegmentConditionWrapper* SegmentCondition;
+	UConfigCatSegmentConditionWrapper* SegmentCondition = nullptr;
 };
 
 USTRUCT(BlueprintType, meta = (DisplayName = "ConfigCat Then Container"))


### PR DESCRIPTION
### Describe the purpose of your pull request
- Fixed runtime errors `FConfigCatConditionContainer::* is not initialized properly.`

### Requirement checklist (only if applicable)
- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
